### PR TITLE
Reduce thumbnail blur loops

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
@@ -1419,9 +1419,8 @@ public class ImageLoader {
                                         image.recycle();
                                         image = nbitmap;
                                     }
-                                    Utilities.blurBitmap(image, 7, opts.inPurgeable ? 0 : 1, image.getWidth(), image.getHeight(), image.getRowBytes());
-                                    Utilities.blurBitmap(image, 7, opts.inPurgeable ? 0 : 1, image.getWidth(), image.getHeight(), image.getRowBytes());
-                                    Utilities.blurBitmap(image, 7, opts.inPurgeable ? 0 : 1, image.getWidth(), image.getHeight(), image.getRowBytes());
+                                    Utilities.blurBitmap(image, 7, opts.inPurgeable ? 0 : 1,
+                                            image.getWidth(), image.getHeight(), image.getRowBytes());
                                 }
                             } else if (blurType == 0 && opts.inPurgeable) {
                                 Utilities.pinBitmap(image);


### PR DESCRIPTION
## Summary
- blur thumbnails only once in ImageLoader instead of calling blur function three times

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef9e000d8832d8aa6578e23d4df73