### PR TITLE
Refactor native lib wait loops

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/FilePathDatabase.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/FilePathDatabase.java
@@ -240,18 +240,13 @@ public class FilePathDatabase {
     public void ensureDatabaseCreated() {
         if (!databaseCreated) {
             if (!NativeLoader.loaded()) {
-                int tryCount = 0;
-                while (!NativeLoader.loaded()) {
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
+                NativeLoader.addOnLoadedRunnable(() -> postRunnable(() -> {
+                    if (!databaseCreated) {
+                        createDatabase(0, false);
+                        databaseCreated = true;
                     }
-                    tryCount++;
-                    if (tryCount > 5) {
-                        break;
-                    }
-                }
+                }));
+                return;
             }
             createDatabase(0, false);
             databaseCreated = true;

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
@@ -281,18 +281,8 @@ public class MessagesStorage extends BaseController {
 
     public void openDatabase(int openTries) {
         if (!NativeLoader.loaded()) {
-            int tryCount = 0;
-            while (!NativeLoader.loaded()) {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                tryCount++;
-                if (tryCount > 5) {
-                    break;
-                }
-            }
+            NativeLoader.addOnLoadedRunnable(() -> storageQueue.postRunnable(() -> openDatabase(openTries)));
+            return;
         }
         File filesDir = ApplicationLoader.getFilesDirFixed();
         if (currentAccount != 0) {


### PR DESCRIPTION
## Summary
- add callback support to `NativeLoader`
- use callbacks in `MessagesStorage.openDatabase`
- use callbacks in `FilePathDatabase.ensureDatabaseCreated`

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef9d89c80832da1faadcaee1888f3