### PR TITLE
Use non-blocking SQLite busy retry

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/SQLite/SQLiteCursor.java
+++ b/TMessagesProj/src/main/java/org/telegram/SQLite/SQLiteCursor.java
@@ -76,27 +76,27 @@ public class SQLiteCursor {
 	}
 
 	public boolean next() throws SQLiteException {
-		int res = preparedStatement.step(preparedStatement.getStatementHandle());
-		if (res == -1) {
-			int repeatCount = 6;
-			while (repeatCount-- != 0) {
-				try {
-					if (BuildVars.LOGS_ENABLED) {
-						FileLog.d("sqlite busy, waiting...");
-					}
-					Thread.sleep(500);
-					res = preparedStatement.step();
-					if (res == 0) {
-						break;
-					}
-				} catch (Exception e) {
-					FileLog.e(e);
-				}
-			}
-			if (res == -1) {
-				throw new SQLiteException("sqlite busy");
-			}
-		}
+                int res = preparedStatement.step(preparedStatement.getStatementHandle());
+                if (res == -1) {
+                        int attempts = 10;
+                        while (attempts-- > 0) {
+                                try {
+                                        if (BuildVars.LOGS_ENABLED) {
+                                                FileLog.d("sqlite busy, retrying...");
+                                        }
+                                        Thread.yield();
+                                        res = preparedStatement.step();
+                                        if (res != -1) {
+                                                break;
+                                        }
+                                } catch (SQLiteException e) {
+                                        throw e;
+                                }
+                        }
+                        if (res == -1) {
+                                throw new SQLiteException("sqlite busy");
+                        }
+                }
 		inRow = (res == 0);
 		return inRow;
 	}


### PR DESCRIPTION
## Summary
- stop sleeping half a second when SQLite is busy
- retry quickly instead

## Testing
- `./gradlew -q help` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef9e16bdc832d8bf6d2538c8bac6f